### PR TITLE
update makefile and deb control to "Razer Nari"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ clean:
 build-deb:
 	mkdir -p build/deb/DEBIAN build/deb/lib/udev/rules.d build/deb/usr/share/pulseaudio/alsa-mixer/profile-sets build/deb/usr/share/pulseaudio/alsa-mixer/paths
 	cp control build/deb/DEBIAN/
-	cp 91-pulseaudio-steelseries-arctis-5.rules build/deb/lib/udev/rules.d/
-	cp steelseries-arctis-5-usb-audio.conf build/deb/usr/share/pulseaudio/alsa-mixer/profile-sets/
-	cp steelseries-arctis-5-output-game.conf build/deb/usr/share/pulseaudio/alsa-mixer/paths/
-	cp steelseries-arctis-5-output-chat.conf build/deb/usr/share/pulseaudio/alsa-mixer/paths/
-	dpkg-deb --build build/deb build/pulseaudio-steelseries-arctis-5_${VERSION}_all.deb
+	cp 91-pulseaudio-razer-nari.rules build/deb/lib/udev/rules.d/
+	cp razer-nari-usb-audio.conf build/deb/usr/share/pulseaudio/alsa-mixer/profile-sets/
+	cp razer-nari-output-game.conf build/deb/usr/share/pulseaudio/alsa-mixer/paths/
+	cp razer-nari-output-chat.conf build/deb/usr/share/pulseaudio/alsa-mixer/paths/
+	dpkg-deb --build build/deb build/pulseaudio-razer-nari_${VERSION}_all.deb
 

--- a/control
+++ b/control
@@ -1,8 +1,8 @@
-Package: pulseaudio-steelseries-arctis-5
+Package: pulseaudio-razer-nari
 Version: 0.3
-Maintainer: Bert Hekman <demontpx@gmail.com>
-Homepage: https://github.com/DemonTPx/steelseries-arctis-5-pulseaudio-profile
+Maintainer: Ilgiz Mustafin <ilgimustafin@gmail.com>
+Homepage: https://github.com/imustafin/razer-nari-pulseaudio-profile
 Architecture: all
 Depends: pulseaudio, udev
 Section: sound
-Description: Pulseaudio configuration for the SteelSeries Arctis 5
+Description: Pulseaudio configuration for the Razer Nari


### PR DESCRIPTION
the Makefile and deb control files were still referencing the
SteelSeries Arctis 5 from which this project was forked.

updating these files allows the appropriate .deb file to be built and
installed via

make && sudo dpkg -i build/pulseaudio-razer-nari_0.3_all.deb &&
pulseaudio -k && pulseaudio --start

note that on my own (ubuntu) system, the new profile did not load until
I ran pulseaudio -k, *without* then running pulseaudio --start
(presumably allowing the system itself to automatically reload/restart
pulseaudio)