### PR TITLE
Input

### DIFF
--- a/91-pulseaudio-razer-nari.rules
+++ b/91-pulseaudio-razer-nari.rules
@@ -1,2 +1,3 @@
 ATTRS{idVendor}=="1532", ATTRS{idProduct}=="051a", ENV{PULSE_PROFILE_SET}="razer-nari-usb-audio.conf"
 ATTRS{idVendor}=="1532", ATTRS{idProduct}=="051c", ENV{PULSE_PROFILE_SET}="razer-nari-usb-audio.conf"
+ATTRS{idVendor}=="1532", ATTRS{idProduct}=="051d", ENV{PULSE_PROFILE_SET}="razer-nari-usb-audio.conf"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build-deb:
 	cp control build/deb/DEBIAN/
 	cp 91-pulseaudio-razer-nari.rules build/deb/lib/udev/rules.d/
 	cp razer-nari-usb-audio.conf build/deb/usr/share/pulseaudio/alsa-mixer/profile-sets/
+	cp razer-nari-input.conf build/deb/usr/share/pulseaudio/alsa-mixer/paths/
 	cp razer-nari-output-game.conf build/deb/usr/share/pulseaudio/alsa-mixer/paths/
 	cp razer-nari-output-chat.conf build/deb/usr/share/pulseaudio/alsa-mixer/paths/
 	dpkg-deb --build build/deb build/pulseaudio-razer-nari_${VERSION}_all.deb
-

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ Install the package [from the AUR](https://aur.archlinux.org/packages/razer-nari
 
 Install by copying the following files:
 
-- `razer-nari-output-game.conf` and `razer-nari-output-chat.conf` to `/usr/share/pulseaudio/alsa-mixer/paths/`
+- `razer-nari-input.conf`, `razer-nari-output-game.conf`, and `razer-nari-output-chat.conf` to `/usr/share/pulseaudio/alsa-mixer/paths/`
 - `razer-nari-usb-audio.conf` to `/usr/share/pulseaudio/alsa-mixer/profile-sets/`
 - `91-pulseaudio-razer-nari.rules` to `/lib/udev/rules.d/`
 
 Script:
 ```
+cp razer-nari-input.conf /usr/share/pulseaudio/alsa-mixer/paths/
 cp razer-nari-output-{game,chat}.conf /usr/share/pulseaudio/alsa-mixer/paths/
 cp razer-nari-usb-audio.conf /usr/share/pulseaudio/alsa-mixer/profile-sets/
 cp 91-pulseaudio-razer-nari.rules /lib/udev/rules.d/

--- a/razer-nari-input.conf
+++ b/razer-nari-input.conf
@@ -1,0 +1,26 @@
+# This file is part of PulseAudio.
+#
+# PulseAudio is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of the
+# License, or (at your option) any later version.
+#
+# PulseAudio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with PulseAudio; if not, see <http://www.gnu.org/licenses/>.
+
+; Razer Nari USB headset microphone path. Works also with Arctis Pro
+; Wireless.
+
+[General]
+description-key = analog-input-microphone-headset
+
+[Element Headset]
+volume = merge
+switch = mute
+override-map.1 = all
+override-map.2 = all-left,all-right

--- a/razer-nari-usb-audio.conf
+++ b/razer-nari-usb-audio.conf
@@ -5,7 +5,7 @@ auto-profiles = yes
 description = Chat
 device-strings = hw:%f,0,0
 channel-map = mono
-paths-input = analog-input-mic
+paths-input = razer-nari-input
 paths-output = razer-nari-output-chat
 
 [Mapping analog-game]


### PR DESCRIPTION
on my own system, the idProduct was different from the value expected
by the .rules file, leading to the microphone not being detected.

Furthermore, the generic analog-input-mic was not being mapped correctly
by my pulseaudio. Copying the steelseries-arctis-7 input rule seems to
be detected correctly and functions as expected, however.

this branch is based on the "makefile" branch (pull-request submitted separately), as it adds to the makefile as part of the change. ie: there would be merge-conflicts otherwise.