### PR TITLE
Make device naming more human-readable

### DIFF
--- a/razer-nari-output-chat.conf
+++ b/razer-nari-output-chat.conf
@@ -21,6 +21,7 @@
 
 [General]
 priority = 50
+description-key = steelseries-arctis-output-chat-common
 
 [Element Com Speaker]
 switch = mute

--- a/razer-nari-output-game.conf
+++ b/razer-nari-output-game.conf
@@ -21,6 +21,7 @@
 
 [General]
 priority = 99
+description-key = steelseries-arctis-output-game-common
 
 [Element PCM]
 switch = mute


### PR DESCRIPTION
Changes the name that appears in pulseaudio from `razer-nari-game-output (Nari Ultimate)` to `Game Output (Nari Ultimate)`. Same-same for chat output.