### PR TITLE
Add easy install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ If you are using pulseaudio `>= 13.99.2+7+g6101798c7, < 14.2-2` then use these i
 - `razer-nari-usb-audio.conf` should go to `/usr/share/alsa-card-profile/mixer/profile-sets/`
 - `91-pulseaudio-razer-nari.rules` to `/lib/udev/rules.d/` as usual
 
+### Other Linux Systems
+
+``cd`` into the ``razer-nari-pulseaudio-profile`` folder and run ``sudo chmod +x install.sh && ./install.sh``
+
 ### Other
 
 Install by copying the following files:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cp razer-nari-input.conf /usr/share/pulseaudio/alsa-mixer/paths/
+cp razer-nari-output-{game,chat}.conf /usr/share/pulseaudio/alsa-mixer/paths/
+cp razer-nari-usb-audio.conf /usr/share/pulseaudio/alsa-mixer/profile-sets/
+cp 91-pulseaudio-razer-nari.rules /lib/udev/rules.d/
+


### PR DESCRIPTION
Adds easy install script for non-arch bash systems (ubuntu, pop, debian, fedora, etc)
Run using: 
`sudo bash install.sh`